### PR TITLE
Makes std into a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,11 @@ keywords = ["wide", "string", "win32", "utf-16", "utf-32"]
 categories = ["text-processing", "encoding"]
 license = "MIT/Apache-2.0"
 
+[features]
+default = ["std"]
+std = ["alloc"]
+alloc = []
+
 [badges]
 appveyor = { repository = "starkat99/widestring-rs" }
 travis-ci = { repository = "starkat99/widestring-rs" }

--- a/src/ucstr.rs
+++ b/src/ucstr.rs
@@ -1,0 +1,518 @@
+use crate::{UChar, WideChar};
+use core::{mem, slice};
+
+/// An error returned from `UCString` and `UCStr` to indicate that a terminating nul value
+/// was missing.
+///
+/// The error optionally returns the ownership of the invalid vector whenever a vector was owned.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MissingNulError<C> {
+    #[cfg(feature = "alloc")]
+    pub(crate) inner: Option<alloc::vec::Vec<C>>,
+    #[cfg(not(feature = "alloc"))]
+    _p: core::marker::PhantomData<C>,
+}
+
+impl<C: UChar> MissingNulError<C> {
+    #[cfg(feature = "alloc")]
+    fn empty() -> Self {
+        Self { inner: None }
+    }
+
+    #[cfg(not(feature = "alloc"))]
+    fn empty() -> Self {
+        Self {
+            _p: core::marker::PhantomData,
+        }
+    }
+
+    /// Consumes this error, returning the underlying vector of `u16` values which generated the
+    /// error in the first place.
+    #[cfg(feature = "alloc")]
+    pub fn into_vec(self) -> Option<alloc::vec::Vec<C>> {
+        self.inner
+    }
+}
+
+impl<C: UChar> core::fmt::Display for MissingNulError<C> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "missing terminating nul value")
+    }
+}
+
+#[cfg(feature = "std")]
+impl<C: UChar> std::error::Error for MissingNulError<C> {
+    fn description(&self) -> &str {
+        "missing terminating nul value"
+    }
+}
+
+/// C-style wide string reference for `UCString`.
+///
+/// `UCStr` is aware of nul values. Unless unchecked conversions are used, all `UCStr`
+/// strings end with a nul-terminator in the underlying buffer and contain no internal nul values.
+/// The strings may still contain invalid or ill-formed UTF-16 or UTF-32 data. These strings are
+/// intended to be used with FFI functions such as Windows API that may require nul-terminated
+/// strings.
+///
+/// `UCStr` can be converted to and from many other string types, including `UString`,
+/// `OsString`, and `String`, making proper Unicode FFI safe and easy.
+///
+/// Please prefer using the type aliases `U16CStr` or `U32CStr` or `WideCStr` to using
+/// this type directly.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct UCStr<C: UChar> {
+    inner: [C],
+}
+
+impl<C: UChar> UCStr<C> {
+    /// Coerces a value into a `UCStr`.
+    pub fn new<S: AsRef<UCStr<C>> + ?Sized>(s: &S) -> &Self {
+        s.as_ref()
+    }
+
+    /// Constructs a `UStr` from a nul-terminated string pointer.
+    ///
+    /// This will scan for nul values beginning with `p`. The first nul value will be used as the
+    /// nul terminator for the string, similar to how libc string functions such as `strlen` work.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe as there is no guarantee that the given pointer is valid or has a
+    /// nul terminator, and the function could scan past the underlying buffer.
+    ///
+    /// `p` must be non-null.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `p` is null.
+    ///
+    /// # Caveat
+    ///
+    /// The lifetime for the returned string is inferred from its usage. To prevent accidental
+    /// misuse, it's suggested to tie the lifetime to whichever source lifetime is safe in the
+    /// context, such as by providing a helper function taking the lifetime of a host value for the
+    /// string, or by explicit annotation.
+    pub unsafe fn from_ptr_str<'a>(p: *const C) -> &'a Self {
+        assert!(!p.is_null());
+        let mut i: isize = 0;
+        while *p.offset(i) != UChar::NUL {
+            i = i + 1;
+        }
+        mem::transmute(slice::from_raw_parts(p, i as usize + 1))
+    }
+
+    /// Constructs a `UStr` from a pointer and a length.
+    ///
+    /// The `len` argument is the number of elements, **not** the number of bytes, and does
+    /// **not** include the nul terminator of the string. Thus, a `len` of 0 is valid and means that
+    /// `p` is a pointer directly to the nul terminator of the string.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe as there is no guarantee that the given pointer is valid for `len`
+    /// elements.
+    ///
+    /// `p` must be non-null, even for zero `len`.
+    ///
+    /// The interior values of the pointer are not scanned for nul. Any interior nul values will
+    /// result in an invalid `UCStr`.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `p` is null or if a nul value is not found at offset `len` of `p`.
+    /// Only pointers with a nul terminator are valid.
+    ///
+    /// # Caveat
+    ///
+    /// The lifetime for the returned string is inferred from its usage. To prevent accidental
+    /// misuse, it's suggested to tie the lifetime to whichever source lifetime is safe in the
+    /// context, such as by providing a helper function taking the lifetime of a host value for the
+    /// string, or by explicit annotation.
+    pub unsafe fn from_ptr_with_nul<'a>(p: *const C, len: usize) -> &'a Self {
+        assert!(*p.offset(len as isize) == UChar::NUL);
+        mem::transmute(slice::from_raw_parts(p, len + 1))
+    }
+
+    /// Constructs a `UCStr` from a slice of values that has a nul terminator.
+    ///
+    /// The slice will be scanned for nul values. When a nul value is found, it is treated as the
+    /// terminator for the string, and the `UCStr` slice will be truncated to that nul.
+    ///
+    /// # Failure
+    ///
+    /// If there are no no nul values in the slice, an error is returned.
+    pub fn from_slice_with_nul(slice: &[C]) -> Result<&Self, MissingNulError<C>> {
+        match slice.iter().position(|x| *x == UChar::NUL) {
+            None => Err(MissingNulError::empty()),
+            Some(i) => Ok(unsafe { UCStr::from_slice_with_nul_unchecked(&slice[..i + 1]) }),
+        }
+    }
+
+    /// Constructs a `UCStr` from a slice of values that has a nul terminator. No
+    /// checking for nul values is performed.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it can lead to invalid `UCStr` values when the slice
+    /// is missing a terminating nul value or there are non-terminating interior nul values
+    /// in the slice.
+    pub unsafe fn from_slice_with_nul_unchecked(slice: &[C]) -> &Self {
+        mem::transmute(slice)
+    }
+
+    /// Copies the wide string to an new owned `UString`.
+    #[cfg(feature = "alloc")]
+    pub fn to_ucstring(&self) -> crate::UCString<C> {
+        #[allow(unused_imports)]
+        use alloc::borrow::ToOwned;
+        unsafe { crate::UCString::from_vec_with_nul_unchecked(self.inner.to_owned()) }
+    }
+
+    /// Copies the wide string to a new owned `UString`.
+    ///
+    /// The `UString` will **not** have a nul terminator.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use widestring::U16CString;
+    /// let wcstr = U16CString::from_str("MyString").unwrap();
+    /// // Convert U16CString to a U16String
+    /// let wstr = wcstr.to_ustring();
+    ///
+    /// // U16CString will have a terminating nul
+    /// let wcvec = wcstr.into_vec_with_nul();
+    /// assert_eq!(wcvec[wcvec.len()-1], 0);
+    /// // The resulting U16String will not have the terminating nul
+    /// let wvec = wstr.into_vec();
+    /// assert_ne!(wvec[wvec.len()-1], 0);
+    /// ```
+    ///
+    /// ```rust
+    /// use widestring::U32CString;
+    /// let wcstr = U32CString::from_str("MyString").unwrap();
+    /// // Convert U32CString to a U32String
+    /// let wstr = wcstr.to_ustring();
+    ///
+    /// // U32CString will have a terminating nul
+    /// let wcvec = wcstr.into_vec_with_nul();
+    /// assert_eq!(wcvec[wcvec.len()-1], 0);
+    /// // The resulting U32String will not have the terminating nul
+    /// let wvec = wstr.into_vec();
+    /// assert_ne!(wvec[wvec.len()-1], 0);
+    /// ```
+    #[cfg(feature = "alloc")]
+    pub fn to_ustring(&self) -> crate::UString<C> {
+        crate::UString::from_vec(self.as_slice())
+    }
+
+    /// Converts to a slice of the wide string.
+    ///
+    /// The slice will **not** include the nul terminator.
+    pub fn as_slice(&self) -> &[C] {
+        &self.inner[..self.len()]
+    }
+
+    /// Converts to a slice of the wide string, including the nul terminator.
+    pub fn as_slice_with_nul(&self) -> &[C] {
+        &self.inner
+    }
+
+    /// Returns a raw pointer to the wide string.
+    ///
+    /// The pointer is valid only as long as the lifetime of this reference.
+    pub fn as_ptr(&self) -> *const C {
+        self.inner.as_ptr()
+    }
+
+    /// Returns the length of the wide string as number of elements (**not** number of bytes)
+    /// **not** including nul terminator.
+    pub fn len(&self) -> usize {
+        self.inner.len() - 1
+    }
+
+    /// Returns whether this wide string contains no data (i.e. is only the nul terminator).
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Converts a `Box<UCStr>` into a `UCString` without copying or allocating.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use widestring::U16CString;
+    ///
+    /// let v = vec![102u16, 111u16, 111u16]; // "foo"
+    /// let c_string = U16CString::new(v.clone()).unwrap();
+    /// let boxed = c_string.into_boxed_ucstr();
+    /// assert_eq!(boxed.into_ucstring(), U16CString::new(v).unwrap());
+    /// ```
+    ///
+    /// ```
+    /// use widestring::U32CString;
+    ///
+    /// let v = vec![102u32, 111u32, 111u32]; // "foo"
+    /// let c_string = U32CString::new(v.clone()).unwrap();
+    /// let boxed = c_string.into_boxed_ucstr();
+    /// assert_eq!(boxed.into_ucstring(), U32CString::new(v).unwrap());
+    /// ```
+    #[cfg(feature = "alloc")]
+    pub fn into_ucstring(self: alloc::boxed::Box<Self>) -> crate::UCString<C> {
+        let raw = alloc::boxed::Box::into_raw(self) as *mut [C];
+        crate::UCString {
+            inner: unsafe { alloc::boxed::Box::from_raw(raw) },
+        }
+    }
+
+    pub(crate) fn from_inner(slice: &[C]) -> &UCStr<C> {
+        unsafe { mem::transmute(slice) }
+    }
+}
+
+impl UCStr<u16> {
+    /// Decodes a wide string to an owned `OsString`.
+    ///
+    /// This makes a string copy of the `U16CStr`. Since `U16CStr` makes no guarantees that it is
+    /// valid UTF-16, there is no guarantee that the resulting `OsString` will be valid data. The
+    /// `OsString` will **not** have a nul terminator.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use widestring::U16CString;
+    /// use std::ffi::OsString;
+    /// let s = "MyString";
+    /// // Create a wide string from the string
+    /// let wstr = U16CString::from_str(s).unwrap();
+    /// // Create an OsString from the wide string
+    /// let osstr = wstr.to_os_string();
+    ///
+    /// assert_eq!(osstr, OsString::from(s));
+    /// ```
+    #[cfg(feature = "std")]
+    pub fn to_os_string(&self) -> std::ffi::OsString {
+        crate::platform::os_from_wide(self.as_slice())
+    }
+
+    /// Copies the wide string to a `String` if it contains valid UTF-16 data.
+    ///
+    /// # Failures
+    ///
+    /// Returns an error if the string contains any invalid UTF-16 data.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use widestring::U16CString;
+    /// let s = "MyString";
+    /// // Create a wide string from the string
+    /// let wstr = U16CString::from_str(s).unwrap();
+    /// // Create a regular string from the wide string
+    /// let s2 = wstr.to_string().unwrap();
+    ///
+    /// assert_eq!(s2, s);
+    /// ```
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<alloc::string::String, alloc::string::FromUtf16Error> {
+        alloc::string::String::from_utf16(self.as_slice())
+    }
+
+    /// Copies the wide string to a `String`.
+    ///
+    /// Any non-Unicode sequences are replaced with U+FFFD REPLACEMENT CHARACTER.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use widestring::U16CString;
+    /// let s = "MyString";
+    /// // Create a wide string from the string
+    /// let wstr = U16CString::from_str(s).unwrap();
+    /// // Create a regular string from the wide string
+    /// let s2 = wstr.to_string_lossy();
+    ///
+    /// assert_eq!(s2, s);
+    /// ```
+    #[cfg(feature = "alloc")]
+    pub fn to_string_lossy(&self) -> alloc::string::String {
+        alloc::string::String::from_utf16_lossy(self.as_slice())
+    }
+}
+
+impl UCStr<u32> {
+    /// Constructs a `U32Str` from a `char` nul-terminated string pointer.
+    ///
+    /// This will scan for nul values beginning with `p`. The first nul value will be used as the
+    /// nul terminator for the string, similar to how libc string functions such as `strlen` work.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe as there is no guarantee that the given pointer is valid or has a
+    /// nul terminator, and the function could scan past the underlying buffer.
+    ///
+    /// `p` must be non-null.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `p` is null.
+    ///
+    /// # Caveat
+    ///
+    /// The lifetime for the returned string is inferred from its usage. To prevent accidental
+    /// misuse, it's suggested to tie the lifetime to whichever source lifetime is safe in the
+    /// context, such as by providing a helper function taking the lifetime of a host value for the
+    /// string, or by explicit annotation.
+    pub unsafe fn from_char_ptr_str<'a>(p: *const char) -> &'a Self {
+        UCStr::from_ptr_str(p as *const u32)
+    }
+
+    /// Constructs a `U32Str` from a `char` pointer and a length.
+    ///
+    /// The `len` argument is the number of `char` elements, **not** the number of bytes, and does
+    /// **not** include the nul terminator of the string. Thus, a `len` of 0 is valid and means that
+    /// `p` is a pointer directly to the nul terminator of the string.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe as there is no guarantee that the given pointer is valid for `len`
+    /// elements.
+    ///
+    /// `p` must be non-null, even for zero `len`.
+    ///
+    /// The interior values of the pointer are not scanned for nul. Any interior nul values will
+    /// result in an invalid `U32CStr`.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `p` is null or if a nul value is not found at offset `len` of `p`.
+    /// Only pointers with a nul terminator are valid.
+    ///
+    /// # Caveat
+    ///
+    /// The lifetime for the returned string is inferred from its usage. To prevent accidental
+    /// misuse, it's suggested to tie the lifetime to whichever source lifetime is safe in the
+    /// context, such as by providing a helper function taking the lifetime of a host value for the
+    /// string, or by explicit annotation.
+    pub unsafe fn from_char_ptr_with_nul<'a>(p: *const char, len: usize) -> &'a Self {
+        UCStr::from_ptr_with_nul(p as *const u32, len)
+    }
+
+    /// Constructs a `U32CStr` from a slice of `char` values that has a nul terminator.
+    ///
+    /// The slice will be scanned for nul values. When a nul value is found, it is treated as the
+    /// terminator for the string, and the `U32CStr` slice will be truncated to that nul.
+    ///
+    /// # Failure
+    ///
+    /// If there are no no nul values in `slice`, an error is returned.
+    pub fn from_char_slice_with_nul(slice: &[char]) -> Result<&Self, MissingNulError<u32>> {
+        UCStr::from_slice_with_nul(unsafe { mem::transmute(slice) })
+    }
+
+    /// Constructs a `U32CStr` from a slice of `char` values that has a nul terminator. No
+    /// checking for nul values is performed.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it can lead to invalid `U32CStr` values when `slice`
+    /// is missing a terminating nul value or there are non-terminating interior nul values
+    /// in the slice.
+    pub unsafe fn from_char_slice_with_nul_unchecked(slice: &[char]) -> &Self {
+        UCStr::from_slice_with_nul_unchecked(mem::transmute(slice))
+    }
+
+    /// Decodes a wide string to an owned `OsString`.
+    ///
+    /// This makes a string copy of the `U32CStr`. Since `U32CStr` makes no guarantees that it is
+    /// valid UTF-32, there is no guarantee that the resulting `OsString` will be valid data. The
+    /// `OsString` will **not** have a nul terminator.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use widestring::U32CString;
+    /// use std::ffi::OsString;
+    /// let s = "MyString";
+    /// // Create a wide string from the string
+    /// let wstr = U32CString::from_str(s).unwrap();
+    /// // Create an OsString from the wide string
+    /// let osstr = wstr.to_os_string();
+    ///
+    /// assert_eq!(osstr, OsString::from(s));
+    /// ```
+    #[cfg(feature = "std")]
+    pub fn to_os_string(&self) -> std::ffi::OsString {
+        self.to_ustring().to_os_string()
+    }
+
+    /// Copies the wide string to a `String` if it contains valid UTF-32 data.
+    ///
+    /// # Failures
+    ///
+    /// Returns an error if the string contains any invalid UTF-32 data.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use widestring::U32CString;
+    /// let s = "MyString";
+    /// // Create a wide string from the string
+    /// let wstr = U32CString::from_str(s).unwrap();
+    /// // Create a regular string from the wide string
+    /// let s2 = wstr.to_string().unwrap();
+    ///
+    /// assert_eq!(s2, s);
+    /// ```
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<alloc::string::String, crate::FromUtf32Error> {
+        self.to_ustring().to_string()
+    }
+
+    /// Copies the wide string to a `String`.
+    ///
+    /// Any non-Unicode sequences are replaced with U+FFFD REPLACEMENT CHARACTER.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use widestring::U32CString;
+    /// let s = "MyString";
+    /// // Create a wide string from the string
+    /// let wstr = U32CString::from_str(s).unwrap();
+    /// // Create a regular string from the wide string
+    /// let s2 = wstr.to_string_lossy();
+    ///
+    /// assert_eq!(s2, s);
+    /// ```
+    #[cfg(feature = "std")]
+    pub fn to_string_lossy(&self) -> alloc::string::String {
+        self.to_ustring().to_string_lossy()
+    }
+}
+
+/// C-style wide string reference for `U16CString`.
+///
+/// `U16CStr` is aware of nul values. Unless unchecked conversions are used, all `U16CStr`
+/// strings end with a nul-terminator in the underlying buffer and contain no internal nul values.
+/// The strings may still contain invalid or ill-formed UTF-16 data. These strings are intended to
+/// be used with FFI functions such as Windows API that may require nul-terminated strings.
+///
+/// `U16CStr` can be converted to and from many other string types, including `U16String`,
+/// `OsString`, and `String`, making proper Unicode FFI safe and easy.
+pub type U16CStr = UCStr<u16>;
+
+/// C-style wide string reference for `U32CString`.
+///
+/// `U32CStr` is aware of nul values. Unless unchecked conversions are used, all `U32CStr`
+/// strings end with a nul-terminator in the underlying buffer and contain no internal nul values.
+/// The strings may still contain invalid or ill-formed UTF-32 data. These strings are intended to
+/// be used with FFI functions such as Windows API that may require nul-terminated strings.
+///
+/// `U32CStr` can be converted to and from many other string types, including `U32String`,
+/// `OsString`, and `String`, making proper Unicode FFI safe and easy.
+pub type U32CStr = UCStr<u32>;
+
+/// Alias for `U16CStr` or `U32CStr` depending on platform. Intended to match typical C `wchar_t` size on platform.
+pub type WideCStr = UCStr<WideChar>;

--- a/src/ustr.rs
+++ b/src/ustr.rs
@@ -1,0 +1,345 @@
+use crate::{UChar, WideChar};
+use core::{char, mem, slice};
+
+/// A possible error value when converting a String from a UTF-32 byte slice.
+///
+/// This type is the error type for the `to_string` method on `U32Str`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FromUtf32Error();
+
+impl core::fmt::Display for FromUtf32Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "error converting from UTF-32 to UTF-8")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for FromUtf32Error {
+    fn description(&self) -> &str {
+        "error converting from UTF-32 to UTF-8"
+    }
+}
+
+/// String slice reference for `U16String`.
+///
+/// `UStr` is to `UString` as `str` is to `String`.
+///
+/// `UStr` is not aware of nul values. Strings may or may not be nul-terminated, and may
+/// contain invalid and ill-formed UTF-16 or UTF-32 data. These strings are intended to be used
+/// with FFI functions that directly use string length, where the strings are known to have proper
+/// nul-termination already, or where strings are merely being passed through without modification.
+///
+/// `UCStr` should be used instead of nul-aware strings are required.
+///
+/// `UStr` can be converted to many other string types, including `OsString` and `String`, making
+/// proper Unicode FFI safe and easy.
+///
+/// Please prefer using the type aliases `U16Str` or `U32Str` or `WideStr` to using this type
+/// directly.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct UStr<C: UChar> {
+    pub(crate) inner: [C],
+}
+
+impl<C: UChar> UStr<C> {
+    /// Coerces a value into a `UStr`.
+    pub fn new<S: AsRef<Self> + ?Sized>(s: &S) -> &Self {
+        s.as_ref()
+    }
+
+    /// Constructs a `UStr` from a pointer and a length.
+    ///
+    /// The `len` argument is the number of elements, **not** the number of bytes.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe as there is no guarantee that the given pointer is valid for `len`
+    /// elements.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `p` is null.
+    ///
+    /// # Caveat
+    ///
+    /// The lifetime for the returned string is inferred from its usage. To prevent accidental
+    /// misuse, it's suggested to tie the lifetime to whichever source lifetime is safe in the
+    /// context, such as by providing a helper function taking the lifetime of a host value for the
+    /// string, or by explicit annotation.
+    pub unsafe fn from_ptr<'a>(p: *const C, len: usize) -> &'a Self {
+        assert!(!p.is_null());
+        mem::transmute(slice::from_raw_parts(p, len))
+    }
+
+    /// Constructs a `UStr` from a slice of code points.
+    ///
+    /// No checks are performed on the slice.
+    pub fn from_slice(slice: &[C]) -> &Self {
+        unsafe { mem::transmute(slice) }
+    }
+
+    /// Copies the wide string to a new owned `UString`.
+    #[cfg(feature = "alloc")]
+    pub fn to_ustring(&self) -> crate::UString<C> {
+        crate::UString::from_vec(&self.inner)
+    }
+
+    /// Converts to a slice of the wide string.
+    pub fn as_slice(&self) -> &[C] {
+        &self.inner
+    }
+
+    /// Returns a raw pointer to the wide string.
+    ///
+    /// The pointer is valid only as long as the lifetime of this reference.
+    pub fn as_ptr(&self) -> *const C {
+        self.inner.as_ptr()
+    }
+
+    /// Returns the length of the wide string as number of elements (**not** number of bytes).
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns whether this wide string contains no data.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Converts a `Box<UStr>` into a `UString` without copying or allocating.
+    #[cfg(feature = "alloc")]
+    pub fn into_ustring(self: alloc::boxed::Box<Self>) -> crate::UString<C> {
+        let boxed =
+            unsafe { alloc::boxed::Box::from_raw(alloc::boxed::Box::into_raw(self) as *mut [C]) };
+        crate::UString {
+            inner: boxed.into_vec(),
+        }
+    }
+}
+
+impl UStr<u16> {
+    /// Decodes a wide string to an owned `OsString`.
+    ///
+    /// This makes a string copy of the `U16Str`. Since `U16Str` makes no guarantees that it is
+    /// valid UTF-16, there is no guarantee that the resulting `OsString` will be valid data.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use widestring::U16String;
+    /// use std::ffi::OsString;
+    /// let s = "MyString";
+    /// // Create a wide string from the string
+    /// let wstr = U16String::from_str(s);
+    /// // Create an OsString from the wide string
+    /// let osstr = wstr.to_os_string();
+    ///
+    /// assert_eq!(osstr, OsString::from(s));
+    /// ```
+    #[cfg(feature = "std")]
+    pub fn to_os_string(&self) -> std::ffi::OsString {
+        crate::platform::os_from_wide(&self.inner)
+    }
+
+    /// Copies the wide string to a `String` if it contains valid UTF-16 data.
+    ///
+    /// # Failures
+    ///
+    /// Returns an error if the string contains any invalid UTF-16 data.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use widestring::U16String;
+    /// let s = "MyString";
+    /// // Create a wide string from the string
+    /// let wstr = U16String::from_str(s);
+    /// // Create a regular string from the wide string
+    /// let s2 = wstr.to_string().unwrap();
+    ///
+    /// assert_eq!(s2, s);
+    /// ```
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<alloc::string::String, alloc::string::FromUtf16Error> {
+        alloc::string::String::from_utf16(&self.inner)
+    }
+
+    /// Copies the wide string to a `String`.
+    ///
+    /// Any non-Unicode sequences are replaced with *U+FFFD REPLACEMENT CHARACTER*.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use widestring::U16String;
+    /// let s = "MyString";
+    /// // Create a wide string from the string
+    /// let wstr = U16String::from_str(s);
+    /// // Create a regular string from the wide string
+    /// let lossy = wstr.to_string_lossy();
+    ///
+    /// assert_eq!(lossy, s);
+    /// ```
+    #[cfg(feature = "alloc")]
+    pub fn to_string_lossy(&self) -> alloc::string::String {
+        alloc::string::String::from_utf16_lossy(&self.inner)
+    }
+}
+
+impl UStr<u32> {
+    /// Constructs a `U32Str` from a `char` pointer and a length.
+    ///
+    /// The `len` argument is the number of `char` elements, **not** the number of bytes.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe as there is no guarantee that the given pointer is valid for `len`
+    /// elements.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `p` is null.
+    ///
+    /// # Caveat
+    ///
+    /// The lifetime for the returned string is inferred from its usage. To prevent accidental
+    /// misuse, it's suggested to tie the lifetime to whichever source lifetime is safe in the
+    /// context, such as by providing a helper function taking the lifetime of a host value for the
+    /// string, or by explicit annotation.
+    pub unsafe fn from_char_ptr<'a>(p: *const char, len: usize) -> &'a Self {
+        UStr::from_ptr(p as *const u32, len)
+    }
+
+    /// Constructs a `U32Str` from a slice of `u32` code points.
+    ///
+    /// No checks are performed on the slice.
+    pub fn from_char_slice(slice: &[char]) -> &Self {
+        unsafe { mem::transmute(slice) }
+    }
+
+    /// Decodes a wide string to an owned `OsString`.
+    ///
+    /// This makes a string copy of the `U32Str`. Since `U32Str` makes no guarantees that it is
+    /// valid UTF-32, there is no guarantee that the resulting `OsString` will be valid data.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use widestring::U32String;
+    /// use std::ffi::OsString;
+    /// let s = "MyString";
+    /// // Create a wide string from the string
+    /// let wstr = U32String::from_str(s);
+    /// // Create an OsString from the wide string
+    /// let osstr = wstr.to_os_string();
+    ///
+    /// assert_eq!(osstr, OsString::from(s));
+    /// ```
+    #[cfg(feature = "std")]
+    pub fn to_os_string(&self) -> std::ffi::OsString {
+        self.to_string_lossy().into()
+    }
+
+    /// Copies the wide string to a `String` if it contains valid UTF-32 data.
+    ///
+    /// # Failures
+    ///
+    /// Returns an error if the string contains any invalid UTF-32 data.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use widestring::U32String;
+    /// let s = "MyString";
+    /// // Create a wide string from the string
+    /// let wstr = U32String::from_str(s);
+    /// // Create a regular string from the wide string
+    /// let s2 = wstr.to_string().unwrap();
+    ///
+    /// assert_eq!(s2, s);
+    /// ```
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<alloc::string::String, FromUtf32Error> {
+        let chars: alloc::vec::Vec<Option<char>> =
+            self.inner.iter().map(|c| char::from_u32(*c)).collect();
+        if chars.iter().any(|c| c.is_none()) {
+            return Err(FromUtf32Error());
+        }
+        let size = chars.iter().filter_map(|o| o.map(|c| c.len_utf8())).sum();
+        let mut vec = alloc::vec::Vec::with_capacity(size);
+        unsafe { vec.set_len(size) };
+        let mut i = 0;
+        for c in chars.iter().filter_map(|&o| o) {
+            c.encode_utf8(&mut vec[i..]);
+            i += c.len_utf8();
+        }
+        Ok(unsafe { alloc::string::String::from_utf8_unchecked(vec) })
+    }
+
+    /// Copies the wide string to a `String`.
+    ///
+    /// Any non-Unicode sequences are replaced with *U+FFFD REPLACEMENT CHARACTER*.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use widestring::U32String;
+    /// let s = "MyString";
+    /// // Create a wide string from the string
+    /// let wstr = U32String::from_str(s);
+    /// // Create a regular string from the wide string
+    /// let lossy = wstr.to_string_lossy();
+    ///
+    /// assert_eq!(lossy, s);
+    /// ```
+    #[cfg(feature = "alloc")]
+    pub fn to_string_lossy(&self) -> alloc::string::String {
+        let chars: alloc::vec::Vec<char> = self
+            .inner
+            .iter()
+            .map(|&c| char::from_u32(c).unwrap_or(char::REPLACEMENT_CHARACTER))
+            .collect();
+        let size = chars.iter().map(|c| c.len_utf8()).sum();
+        let mut vec = alloc::vec::Vec::with_capacity(size);
+        unsafe { vec.set_len(size) };
+        let mut i = 0;
+        for c in chars {
+            c.encode_utf8(&mut vec[i..]);
+            i += c.len_utf8();
+        }
+        unsafe { alloc::string::String::from_utf8_unchecked(vec) }
+    }
+}
+
+/// String slice reference for `U16String`.
+///
+/// `U16Str` is to `U16String` as `str` is to `String`.
+///
+/// `U16Str` is not aware of nul values. Strings may or may not be nul-terminated, and may
+/// contain invalid and ill-formed UTF-16 data. These strings are intended to be used with
+/// FFI functions that directly use string length, where the strings are known to have proper
+/// nul-termination already, or where strings are merely being passed through without modification.
+///
+/// `WideCStr` should be used instead of nul-aware strings are required.
+///
+/// `U16Str` can be converted to many other string types, including `OsString` and `String`, making
+/// proper Unicode FFI safe and easy.
+pub type U16Str = UStr<u16>;
+
+/// String slice reference for `U32String`.
+///
+/// `U32Str` is to `U32String` as `str` is to `String`.
+///
+/// `U32Str` is not aware of nul values. Strings may or may not be nul-terminated, and may
+/// contain invalid and ill-formed UTF-32 data. These strings are intended to be used with
+/// FFI functions that directly use string length, where the strings are known to have proper
+/// nul-termination already, or where strings are merely being passed through without modification.
+///
+/// `WideCStr` should be used instead of nul-aware strings are required.
+///
+/// `U32Str` can be converted to many other string types, including `OsString` and `String`, making
+/// proper Unicode FFI safe and easy.
+pub type U32Str = UStr<u32>;
+
+/// Alias for `U16Str` or `U32Str` depending on platform. Intended to match typical C `wchar_t` size on platform.
+pub type WideStr = UStr<WideChar>;


### PR DESCRIPTION
This pull request makes `std` and `alloc` into default features. This way, the user may disable these features in order to use `UStr` and `UCStr` without `std`.

There should be no changes for current users.

`U*Str` were moved into their own modules. Most aliases were moved out of the main module. This way, the entire `U*String` modules could be `alloc` gated.