### PR TITLE
Spring cleaning!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ repository = "https://github.com/starkat99/widestring-rs.git"
 readme = "README.md"
 keywords = ["wide", "string", "win32", "utf-16", "utf-32"]
 categories = ["text-processing", "encoding"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
+edition = "2018"
 
 [features]
 default = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,7 @@
 //! # }
 //! ```
 
-#![deny(future_incompatible)]
+#![deny(future_incompatible, rust_2018_idioms)]
 #![warn(
     unused,
     anonymous_parameters,
@@ -193,8 +193,6 @@
 
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 extern crate alloc;
-#[cfg(feature = "std")]
-extern crate core;
 
 use core::fmt::Debug;
 

--- a/src/ucstr.rs
+++ b/src/ucstr.rs
@@ -1,5 +1,5 @@
 use crate::{UChar, WideChar};
-use core::{mem, slice};
+use core::slice;
 
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 use alloc::{
@@ -112,9 +112,10 @@ impl<C: UChar> UCStr<C> {
         assert!(!p.is_null());
         let mut i: isize = 0;
         while *p.offset(i) != UChar::NUL {
-            i = i + 1;
+            i += 1;
         }
-        mem::transmute(slice::from_raw_parts(p, i as usize + 1))
+        let slice: *const [C] = slice::from_raw_parts(p, i as usize + 1);
+        &*(slice as *const UCStr<C>)
     }
 
     /// Constructs a `UStr` from a pointer and a length.
@@ -145,8 +146,9 @@ impl<C: UChar> UCStr<C> {
     /// context, such as by providing a helper function taking the lifetime of a host value for the
     /// string, or by explicit annotation.
     pub unsafe fn from_ptr_with_nul<'a>(p: *const C, len: usize) -> &'a Self {
-        assert!(*p.offset(len as isize) == UChar::NUL);
-        mem::transmute(slice::from_raw_parts(p, len + 1))
+        assert!(*p.add(len) == UChar::NUL);
+        let slice: *const [C] = slice::from_raw_parts(p, len + 1);
+        &*(slice as *const UCStr<C>)
     }
 
     /// Constructs a `UCStr` from a slice of values that has a nul terminator.
@@ -173,7 +175,8 @@ impl<C: UChar> UCStr<C> {
     /// is missing a terminating nul value or there are non-terminating interior nul values
     /// in the slice.
     pub unsafe fn from_slice_with_nul_unchecked(slice: &[C]) -> &Self {
-        mem::transmute(slice)
+        let slice: *const [C] = slice;
+        &*(slice as *const UCStr<C>)
     }
 
     /// Copies the wide string to an new owned `UString`.
@@ -281,7 +284,8 @@ impl<C: UChar> UCStr<C> {
 
     #[cfg(feature = "alloc")]
     pub(crate) fn from_inner(slice: &[C]) -> &UCStr<C> {
-        unsafe { mem::transmute(slice) }
+        let slice: *const [C] = slice;
+        unsafe { &*(slice as *const UCStr<C>) }
     }
 }
 
@@ -422,7 +426,8 @@ impl UCStr<u32> {
     ///
     /// If there are no no nul values in `slice`, an error is returned.
     pub fn from_char_slice_with_nul(slice: &[char]) -> Result<&Self, MissingNulError<u32>> {
-        UCStr::from_slice_with_nul(unsafe { mem::transmute(slice) })
+        let slice: *const [char] = slice;
+        UCStr::from_slice_with_nul(unsafe { &*(slice as *const [u32]) })
     }
 
     /// Constructs a `U32CStr` from a slice of `char` values that has a nul terminator. No
@@ -434,7 +439,8 @@ impl UCStr<u32> {
     /// is missing a terminating nul value or there are non-terminating interior nul values
     /// in the slice.
     pub unsafe fn from_char_slice_with_nul_unchecked(slice: &[char]) -> &Self {
-        UCStr::from_slice_with_nul_unchecked(mem::transmute(slice))
+        let slice: *const [char] = slice;
+        UCStr::from_slice_with_nul_unchecked(&*(slice as *const [u32]))
     }
 
     /// Decodes a wide string to an owned `OsString`.

--- a/src/ucstr.rs
+++ b/src/ucstr.rs
@@ -50,7 +50,7 @@ impl<C: UChar> MissingNulError<C> {
 }
 
 impl<C: UChar> core::fmt::Display for MissingNulError<C> {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "missing terminating nul value")
     }
 }

--- a/src/ucstring.rs
+++ b/src/ucstring.rs
@@ -1307,8 +1307,8 @@ impl<C: UChar> From<UCString<C>> for UString<C> {
     }
 }
 
-impl<'a, C: UChar, T: ?Sized + AsRef<UCStr<C>>> From<&'a T> for UCString<C> {
-    fn from(s: &'a T) -> Self {
+impl<C: UChar, T: ?Sized + AsRef<UCStr<C>>> From<&'_ T> for UCString<C> {
+    fn from(s: &T) -> Self {
         s.as_ref().to_ucstring()
     }
 }
@@ -1468,7 +1468,7 @@ impl<C: UChar> Into<Vec<C>> for NulError<C> {
 }
 
 impl<C: UChar> core::fmt::Display for NulError<C> {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "nul value found at position {}", self.0)
     }
 }

--- a/src/ucstring.rs
+++ b/src/ucstring.rs
@@ -13,6 +13,7 @@ use alloc::{
 use std::{
     borrow::{Cow, ToOwned},
     boxed::Box,
+    str::FromStr,
     vec::Vec,
 };
 
@@ -395,6 +396,14 @@ impl<C: UChar> UCString<C> {
     }
 }
 
+impl FromStr for UCString<u16> {
+    type Err = NulError<u16>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_str(s)
+    }
+}
+
 impl UCString<u16> {
     /// Constructs a `U16CString` from a `str`.
     ///
@@ -425,6 +434,7 @@ impl UCString<u16> {
     /// assert!(res.is_err());
     /// assert_eq!(res.err().unwrap().nul_position(), 2);
     /// ```
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: impl AsRef<str>) -> Result<Self, NulError<u16>> {
         let v: Vec<u16> = s.as_ref().encode_utf16().collect();
         UCString::new(v)
@@ -738,6 +748,14 @@ impl UCString<u16> {
     }
 }
 
+impl FromStr for UCString<u32> {
+    type Err = NulError<u32>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_str(s)
+    }
+}
+
 impl UCString<u32> {
     /// Constructs a `U32CString` from a container of wide character data.
     ///
@@ -866,6 +884,7 @@ impl UCString<u32> {
     /// assert!(res.is_err());
     /// assert_eq!(res.err().unwrap().nul_position(), 2);
     /// ```
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: impl AsRef<str>) -> Result<Self, NulError<u32>> {
         let v: Vec<char> = s.as_ref().chars().collect();
         UCString::from_chars(v)

--- a/src/ucstring.rs
+++ b/src/ucstring.rs
@@ -13,6 +13,7 @@ use alloc::{
 use std::{
     borrow::{Cow, ToOwned},
     boxed::Box,
+    convert::TryFrom,
     str::FromStr,
     vec::Vec,
 };
@@ -1290,6 +1291,38 @@ impl UCString<u32> {
 impl<C: UChar> Into<Vec<C>> for UCString<C> {
     fn into(self) -> Vec<C> {
         self.into_vec()
+    }
+}
+
+impl TryFrom<String> for UCString<u16> {
+    type Error = NulError<u16>;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::from_str(value)
+    }
+}
+
+impl TryFrom<String> for UCString<u32> {
+    type Error = NulError<u32>;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::from_str(value)
+    }
+}
+
+impl TryFrom<&'_ str> for UCString<u16> {
+    type Error = NulError<u16>;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::from_str(value)
+    }
+}
+
+impl TryFrom<&'_ str> for UCString<u32> {
+    type Error = NulError<u32>;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::from_str(value)
     }
 }
 

--- a/src/ucstring.rs
+++ b/src/ucstring.rs
@@ -1326,6 +1326,22 @@ impl TryFrom<&'_ str> for UCString<u32> {
     }
 }
 
+impl TryFrom<&'_ String> for UCString<u16> {
+    type Error = NulError<u16>;
+
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        Self::from_str(value)
+    }
+}
+
+impl TryFrom<&'_ String> for UCString<u32> {
+    type Error = NulError<u32>;
+
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        Self::from_str(value)
+    }
+}
+
 impl<'a> From<UCString<u16>> for Cow<'a, UCStr<u16>> {
     fn from(s: UCString<u16>) -> Cow<'a, UCStr<u16>> {
         Cow::Owned(s)

--- a/src/ustr.rs
+++ b/src/ustr.rs
@@ -21,7 +21,7 @@ use std::{
 pub struct FromUtf32Error();
 
 impl core::fmt::Display for FromUtf32Error {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "error converting from UTF-32 to UTF-8")
     }
 }

--- a/src/ustring.rs
+++ b/src/ustring.rs
@@ -541,6 +541,18 @@ impl From<String> for UString<u32> {
     }
 }
 
+impl From<&'_ str> for UString<u16> {
+    fn from(s: &str) -> Self {
+        Self::from_str(s)
+    }
+}
+
+impl From<&'_ str> for UString<u32> {
+    fn from(s: &str) -> Self {
+        Self::from_str(s)
+    }
+}
+
 #[cfg(feature = "std")]
 impl From<std::ffi::OsString> for UString<u16> {
     fn from(s: std::ffi::OsString) -> Self {

--- a/src/ustring.rs
+++ b/src/ustring.rs
@@ -574,6 +574,18 @@ impl From<&'_ str> for UString<u32> {
     }
 }
 
+impl From<&'_ String> for UString<u16> {
+    fn from(s: &String) -> Self {
+        Self::from_str(s)
+    }
+}
+
+impl From<&'_ String> for UString<u32> {
+    fn from(s: &String) -> Self {
+        Self::from_str(s)
+    }
+}
+
 #[cfg(feature = "std")]
 impl From<std::ffi::OsString> for UString<u16> {
     fn from(s: std::ffi::OsString) -> Self {

--- a/src/ustring.rs
+++ b/src/ustring.rs
@@ -1,7 +1,7 @@
 use crate::{UChar, UStr, WideChar};
 use core::borrow::Borrow;
 use core::ops::{Deref, Index, RangeFull};
-use core::{char, cmp, mem, slice};
+use core::{char, cmp, slice};
 
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 use alloc::{
@@ -60,6 +60,7 @@ use std::{
 /// assert_eq!(rust_str, "Test");
 /// ```
 #[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
 pub struct UString<C: UChar> {
     pub(crate) inner: Vec<C>,
 }
@@ -387,9 +388,9 @@ impl UString<u32> {
     /// let wstr = U32String::from_chars(v);
     /// # assert_eq!(wstr.into_vec(), cloned);
     /// ```
-    pub fn from_chars(raw: impl Into<Vec<char>>) -> Self {
+    pub fn from_chars(raw: Vec<char>) -> Self {
         UString {
-            inner: unsafe { mem::transmute(raw.into()) },
+            inner: raw.into_iter().map(u32::from).collect::<Vec<_>>(),
         }
     }
 

--- a/src/ustring.rs
+++ b/src/ustring.rs
@@ -14,6 +14,8 @@ use alloc::{
 use std::{
     borrow::{Cow, ToOwned},
     boxed::Box,
+    convert::Infallible,
+    str::FromStr,
     string::String,
     vec::Vec,
 };
@@ -287,6 +289,14 @@ impl<C: UChar> UString<C> {
     }
 }
 
+impl FromStr for UString<u16> {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from_str(s))
+    }
+}
+
 impl UString<u16> {
     /// Encodes a `U16String` copy from a `str`.
     ///
@@ -303,6 +313,7 @@ impl UString<u16> {
     ///
     /// assert_eq!(wstr.to_string().unwrap(), s);
     /// ```
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str<S: AsRef<str> + ?Sized>(s: &S) -> Self {
         Self {
             inner: s.as_ref().encode_utf16().collect(),
@@ -373,6 +384,14 @@ impl UString<u16> {
     }
 }
 
+impl FromStr for UString<u32> {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from_str(s))
+    }
+}
+
 impl UString<u32> {
     /// Constructs a `U32String` from a vector of UTF-32 data.
     ///
@@ -409,6 +428,7 @@ impl UString<u32> {
     ///
     /// assert_eq!(wstr.to_string().unwrap(), s);
     /// ```
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str<S: AsRef<str> + ?Sized>(s: &S) -> Self {
         let v: Vec<char> = s.as_ref().chars().collect();
         UString::from_chars(v)


### PR DESCRIPTION
Hey!

Couldn't think of a better title :smile:. Found some issues, both ergonomic and soundness, while using this crate for a project, so thought I'd contribute the fixes.

Summary of improvements:

* Fix SPDX license code (the slash delimiter was deprecated some time ago)
* Update to 2018 edition
* Add `From<T>` for `&'_ str`, `String` and `&'_ String`, plus `TryFrom<T>` variants where it made sense
* Removed all uses of `transmute` and replaced with clippy suggestions
* Implemented 2018 idioms (like no hidden lifetimes) and implemented clippy's style nitpicking

