### PR TITLE
Remove `unsafe` qualifiers from `as_mut_ptr` and `as_mut_ptr_range`

### DIFF
--- a/src/ucstr.rs
+++ b/src/ucstr.rs
@@ -571,14 +571,9 @@ macro_rules! ucstr_common_impl {
             ///
             /// Modifying the container referenced by this string may cause its buffer to be
             /// reallocated, which would also make any pointers to it invalid.
-            ///
-            /// # Safety
-            ///
-            /// This method is unsafe because you can violate the invariants of this type when
-            /// mutating the memory the pointer points to (i.e. by adding interior nul values).
             #[inline]
             #[must_use]
-            pub unsafe fn as_mut_ptr(&mut self) -> *mut $uchar {
+            pub fn as_mut_ptr(&mut self) -> *mut $uchar {
                 self.inner.as_mut_ptr()
             }
 
@@ -613,14 +608,9 @@ macro_rules! ucstr_common_impl {
             ///
             /// This function is useful for interacting with foreign interfaces which use two
             /// pointers to refer to a range of elements in memory, as is common in C++.
-            ///
-            /// # Safety
-            ///
-            /// This method is unsafe because you can violate the invariants of this type when
-            /// mutating the memory the pointer points to (i.e. by adding interior nul values).
             #[inline]
             #[must_use]
-            pub unsafe fn as_mut_ptr_range(&mut self) -> Range<*mut $uchar> {
+            pub fn as_mut_ptr_range(&mut self) -> Range<*mut $uchar> {
                 self.inner.as_mut_ptr_range()
             }
 

--- a/src/utfstr.rs
+++ b/src/utfstr.rs
@@ -152,18 +152,9 @@ macro_rules! utfstr_common_impl {
             /// Converts a mutable string slice to a mutable pointer.
             ///
             /// This pointer will be pointing to the first element of the string slice.
-            ///
-            /// # Safety
-            ///
-            /// This function is unsafe because you can violate the invariants of this type when
-            /// mutating the slice. The caller must ensure that the contents of the slice is valid
-            /// UTF before the borrow ends and the underlying string is used.
-            ///
-            /// Use of this string type whose contents have been mutated to invalid UTF is
-            /// undefined behavior.
             #[inline]
             #[must_use]
-            pub unsafe fn as_mut_ptr(&mut self) -> *mut $uchar {
+            pub fn as_mut_ptr(&mut self) -> *mut $uchar {
                 self.inner.as_mut_ptr()
             }
 


### PR DESCRIPTION
As the documentation of [`str::as_mut_ptr`](https://doc.rust-lang.org/std/primitive.str.html#method.as_mut_ptr) says, "It is your responsibility to make sure that the string slice only gets modified in a way that it remains valid UTF-8." The same should also apply to `UCStr::as_mut_ptr` and friends.