### PR TITLE
Reduce collision potential for macros

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -9,23 +9,23 @@ macro_rules! implement_utf16_macro {
                     $crate::internals::length_as_utf16(_WIDESTRING_U16_MACRO_UTF8) + $extra_len;
                 const _WIDESTRING_U16_MACRO_UTF16: [$crate::internals::core::primitive::u16;
                         _WIDESTRING_U16_MACRO_LEN] = {
-                    let mut buffer: [$crate::internals::core::primitive::u16; _WIDESTRING_U16_MACRO_LEN] = [0; _WIDESTRING_U16_MACRO_LEN];
-                    let mut bytes = _WIDESTRING_U16_MACRO_UTF8.as_bytes();
-                    let mut i = 0;
-                    while let $crate::internals::core::option::Option::Some((ch, rest)) = $crate::internals::next_code_point(bytes) {
-                        bytes = rest;
+                    let mut _widestring_buffer: [$crate::internals::core::primitive::u16; _WIDESTRING_U16_MACRO_LEN] = [0; _WIDESTRING_U16_MACRO_LEN];
+                    let mut _widestring_bytes = _WIDESTRING_U16_MACRO_UTF8.as_bytes();
+                    let mut _widestring_i = 0;
+                    while let $crate::internals::core::option::Option::Some((_widestring_ch, _widestring_rest)) = $crate::internals::next_code_point(_widestring_bytes) {
+                        _widestring_bytes = _widestring_rest;
                         // https://doc.rust-lang.org/std/primitive.char.html#method.encode_utf16
-                        if ch & 0xFFFF == ch {
-                            buffer[i] = ch as $crate::internals::core::primitive::u16;
-                            i += 1;
+                        if _widestring_ch & 0xFFFF == _widestring_ch {
+                            _widestring_buffer[_widestring_i] = _widestring_ch as $crate::internals::core::primitive::u16;
+                            _widestring_i += 1;
                         } else {
-                            let code = ch - 0x1_0000;
-                            buffer[i] = 0xD800 | ((code >> 10) as $crate::internals::core::primitive::u16);
-                            buffer[i + 1] = 0xDC00 | ((code as $crate::internals::core::primitive::u16) & 0x3FF);
-                            i += 2;
+                            let _widestring_code = _widestring_ch - 0x1_0000;
+                            _widestring_buffer[_widestring_i] = 0xD800 | ((_widestring_code >> 10) as $crate::internals::core::primitive::u16);
+                            _widestring_buffer[_widestring_i + 1] = 0xDC00 | ((_widestring_code as $crate::internals::core::primitive::u16) & 0x3FF);
+                            _widestring_i += 2;
                         }
                     }
-                    buffer
+                    _widestring_buffer
                 };
                 #[allow(unused_unsafe)]
                 unsafe { $crate::$str::$fn(&_WIDESTRING_U16_MACRO_UTF16) }
@@ -100,15 +100,15 @@ macro_rules! implement_utf32_macro {
                     $crate::internals::length_as_utf32(_WIDESTRING_U32_MACRO_UTF8) + $extra_len;
                 const _WIDESTRING_U32_MACRO_UTF32: [$crate::internals::core::primitive::u32;
                         _WIDESTRING_U32_MACRO_LEN] = {
-                    let mut buffer: [$crate::internals::core::primitive::u32; _WIDESTRING_U32_MACRO_LEN] = [0; _WIDESTRING_U32_MACRO_LEN];
-                    let mut bytes = _WIDESTRING_U32_MACRO_UTF8.as_bytes();
-                    let mut i = 0;
-                    while let $crate::internals::core::option::Option::Some((ch, rest)) = $crate::internals::next_code_point(bytes) {
-                        bytes = rest;
-                        buffer[i] = ch;
-                        i += 1;
+                    let mut _widestring_buffer: [$crate::internals::core::primitive::u32; _WIDESTRING_U32_MACRO_LEN] = [0; _WIDESTRING_U32_MACRO_LEN];
+                    let mut _widestring_bytes = _WIDESTRING_U32_MACRO_UTF8.as_bytes();
+                    let mut _widestring_i = 0;
+                    while let $crate::internals::core::option::Option::Some((_widestring_ch, _widestring_rest)) = $crate::internals::next_code_point(_widestring_bytes) {
+                        _widestring_bytes = _widestring_rest;
+                        _widestring_buffer[_widestring_i] = _widestring_ch;
+                        _widestring_i += 1;
                     }
-                    buffer
+                    _widestring_buffer
                 };
                 #[allow(unused_unsafe)]
                 unsafe { $crate::$str::$fn(&_WIDESTRING_U32_MACRO_UTF32) }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -9,10 +9,10 @@ macro_rules! implement_utf16_macro {
                     $crate::internals::length_as_utf16(_WIDESTRING_U16_MACRO_UTF8) + $extra_len;
                 const _WIDESTRING_U16_MACRO_UTF16: [$crate::internals::core::primitive::u16;
                         _WIDESTRING_U16_MACRO_LEN] = {
-                    let mut buffer = [0u16; _WIDESTRING_U16_MACRO_LEN];
+                    let mut buffer: [$crate::internals::core::primitive::u16; _WIDESTRING_U16_MACRO_LEN] = [0; _WIDESTRING_U16_MACRO_LEN];
                     let mut bytes = _WIDESTRING_U16_MACRO_UTF8.as_bytes();
                     let mut i = 0;
-                    while let Some((ch, rest)) = $crate::internals::next_code_point(bytes) {
+                    while let $crate::internals::core::option::Option::Some((ch, rest)) = $crate::internals::next_code_point(bytes) {
                         bytes = rest;
                         // https://doc.rust-lang.org/std/primitive.char.html#method.encode_utf16
                         if ch & 0xFFFF == ch {
@@ -100,10 +100,10 @@ macro_rules! implement_utf32_macro {
                     $crate::internals::length_as_utf32(_WIDESTRING_U32_MACRO_UTF8) + $extra_len;
                 const _WIDESTRING_U32_MACRO_UTF32: [$crate::internals::core::primitive::u32;
                         _WIDESTRING_U32_MACRO_LEN] = {
-                    let mut buffer = [0u32; _WIDESTRING_U32_MACRO_LEN];
+                    let mut buffer: [$crate::internals::core::primitive::u32; _WIDESTRING_U32_MACRO_LEN] = [0; _WIDESTRING_U32_MACRO_LEN];
                     let mut bytes = _WIDESTRING_U32_MACRO_UTF8.as_bytes();
                     let mut i = 0;
-                    while let Some((ch, rest)) = $crate::internals::next_code_point(bytes) {
+                    while let $crate::internals::core::option::Option::Some((ch, rest)) = $crate::internals::next_code_point(bytes) {
                         bytes = rest;
                         buffer[i] = ch;
                         i += 1;


### PR DESCRIPTION
I encountered a name collision when using thie macros from this crate together with [`iced-x86`](https://crates.io/crates/iced-x86):

```rust
use iced_x86::code_asm::registers::gpr8::ch;
fn main() {
    widestring::u16cstr!("test");
}
```

which results in the following errors

```
error[E0308]: mismatched types
  --> src\lib.rs:37:5
   |
37 |     widestring::u16cstr!("test");
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |     |
   |     expected `u32`, found struct `AsmRegister8`
   |     this expression has type `std::option::Option<(u32, &[u8])>`
   |
   = note: this error originates in the macro `widestring::u16cstr` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0369]: no implementation for `AsmRegister8 & {integer}`  --> src\lib.rs:37:5
   |
37 |     widestring::u16cstr!("test");
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |     |
   |     AsmRegister8
   |     {integer}
   |
   = note: this error originates in the macro `widestring::u16cstr` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0369]: cannot subtract `{integer}` from `AsmRegister8` 
  --> src\lib.rs:37:5
   |
37 |     widestring::u16cstr!("test");
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |     |
   |     AsmRegister8
   |     {integer}
   |
   = note: this error originates in the macro `widestring::u16cstr` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0605]: non-primitive cast: `AsmRegister8` as `u16`     
  --> src\lib.rs:37:5
   |
37 |     widestring::u16cstr!("test");
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ an `as` expression can only be used to convert between primitive types or to coerce to a specific trait object
   |
   = note: this error originates in the macro `widestring::u16cstr` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This pull request adds the prefix `_widestring_` to all locals declared in the macros and also uses fully qualified names for one occurance of `u16`/`u32` and `Some`.
