### PR TITLE
Use `ManuallyDrop` instead of `mem::forget`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,4 +73,4 @@ jobs:
           command: miri
           args: test
         env:
-          MIRIFLAGS: -Zmiri-strict-provenance
+          MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-retag-fields

--- a/src/ucstring.rs
+++ b/src/ucstring.rs
@@ -10,7 +10,7 @@ use alloc::{
 };
 use core::{
     borrow::{Borrow, BorrowMut},
-    cmp, mem,
+    cmp, mem::{self, ManuallyDrop},
     ops::{Deref, DerefMut, Index},
     ptr,
     slice::{self, SliceIndex},
@@ -376,9 +376,10 @@ macro_rules! ucstring_common_impl {
 
             /// Bypass "move out of struct which implements [`Drop`] trait" restriction.
             fn into_inner(self) -> Box<[$uchar]> {
-                let result = unsafe { ptr::read(&self.inner) };
-                mem::forget(self);
-                result
+                let v = ManuallyDrop::new(self);
+                unsafe {
+                    ptr::read(&v.inner)
+                }
             }
         }
 

--- a/src/ucstring.rs
+++ b/src/ucstring.rs
@@ -10,7 +10,8 @@ use alloc::{
 };
 use core::{
     borrow::{Borrow, BorrowMut},
-    cmp, mem::{self, ManuallyDrop},
+    cmp,
+    mem::{self, ManuallyDrop},
     ops::{Deref, DerefMut, Index},
     ptr,
     slice::{self, SliceIndex},


### PR DESCRIPTION
With field retagging in Stacked Borrows, `self` is invalidated by the move into `mem::forget`. Using `ManuallyDrop` does not cause UB.